### PR TITLE
Update LambdaDeployemnt with simpler logGroup configuration

### DIFF
--- a/deployment/lib/Constructs/LambdaDeployment.ts
+++ b/deployment/lib/Constructs/LambdaDeployment.ts
@@ -1,8 +1,8 @@
 import { Duration } from 'aws-cdk-lib';
-import { Effect, ManagedPolicy, PolicyDocument, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { Effect, ManagedPolicy, PolicyDocument, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { Tracing } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
-import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { LogGroup } from "aws-cdk-lib/aws-logs";
 import { Construct } from 'constructs';
 import type { Runtime } from 'aws-cdk-lib/aws-lambda';
 
@@ -17,13 +17,6 @@ export class LambdaDeployment extends Construct {
   constructor(scope: Construct, id: string, props: LambdaDeploymentProps) {
     super(scope, id);
 
-    const allowLoggingPolicy = new PolicyStatement({
-      sid: 'AllowRemixServerToCreateLogs',
-      effect: Effect.ALLOW,
-      actions: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents', 'logs:DescribeLogStreams'],
-      resources: ['arn:aws:logs:*:*:*']
-    });
-
     const role = new Role(this, 'RemixServerRole', {
       description: 'Service Role for the Remix Server, managed by CDK',
       assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
@@ -32,36 +25,27 @@ export class LambdaDeployment extends Construct {
       ]
     });
 
-    const logRetentionRole = new Role(this, 'RemixServerLogRetentionRole', {
-      description: 'Log Retention Role for the Remix Server, managed by CDK',
-      assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
-      inlinePolicies: {
-        'AllowRemixServerToChangeLogRetention': new PolicyDocument({
-          statements: [allowLoggingPolicy]
-        })
-      }
-    });
-
     // The Lambda function names have a hard limit on size of 64 characters.
     // We need to truncate the environment name to fit within that limit.
     const env = scope.node.tryGetContext('environmentName').replace(/[^a-zA-Z0-9-]/g, '-').substring(0, 50);
 
+    // Define a consistent log group so that logs go to the same place when new versions are deployed.
+    const logGroup = new LogGroup(this, "LogGroup", {
+      logGroupName: `/aws/lambda/${env}-remix-server`,
+    });
+
     this.lambdaFunction = new NodejsFunction(this, 'Default', {
-      functionName: `${env}-remix-server`,
       description: 'Remix Server, managed by CDK',
       runtime: props.runtime,
       entry: props.server,
       bundling: {
         nodeModules: ['@remix-run/architect', 'react', 'react-dom']
       },
+      logGroup: logGroup,
       timeout: Duration.seconds(10),
-      logRetention: RetentionDays.THREE_DAYS,
       tracing: Tracing.ACTIVE,
       role: role,
-      logRetentionRole: logRetentionRole
     });
-
-    this.lambdaFunction.addToRolePolicy(allowLoggingPolicy);
   }
 
   lambda() {


### PR DESCRIPTION
`logGroup` is a recently available configuration that makes it easier to manage where logs are sent from lambdas (https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda.Function.html#loggroup)

Instead of keeping the function name static, we can use a static `logGroupName` to get the same benefits.